### PR TITLE
Add WPProbe command so the Docker image is ready to use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.23-alpine
 
 RUN go install github.com/Chocapikk/wpprobe@latest
+RUN wpprobe update
+RUN wpprobe update-db
 
 ENTRYPOINT ["/go/bin/wpprobe"]


### PR DESCRIPTION
When you build and use the Docker image from a cloned repository, you may encounter an error related to version update and database update.
To resolve this, I have added commands during the build process that ensures the database is updated and version is also updated.