### PR TITLE
fix: Theme detection in inline style/script blocks

### DIFF
--- a/internal/scanner/html.go
+++ b/internal/scanner/html.go
@@ -136,16 +136,23 @@ func extractSlugsFromReader(r io.Reader, pluginDest, themeDest map[string]struct
 			}
 			return z.Err()
 		}
-		if tt != html.StartTagToken && tt != html.SelfClosingTagToken {
-			continue
-		}
 
-		tok := z.Token()
-		for _, attr := range tok.Attr {
-			val := attr.Val
-			extractSlugFromPath(val, "wp-content/plugins/", pluginDest)
-			extractSlugFromPath(val, "wp-content/uploads/", pluginDest)
-			extractSlugFromPath(val, "wp-content/themes/", themeDest)
+		switch tt {
+		case html.StartTagToken, html.SelfClosingTagToken:
+			tok := z.Token()
+			for _, attr := range tok.Attr {
+				val := attr.Val
+				extractSlugFromPath(val, "wp-content/plugins/", pluginDest)
+				extractSlugFromPath(val, "wp-content/uploads/", pluginDest)
+				extractSlugFromPath(val, "wp-content/themes/", themeDest)
+			}
+		case html.TextToken:
+			text := string(z.Text())
+			if strings.Contains(text, "wp-content/") {
+				extractSlugFromPath(text, "wp-content/plugins/", pluginDest)
+				extractSlugFromPath(text, "wp-content/uploads/", pluginDest)
+				extractSlugFromPath(text, "wp-content/themes/", themeDest)
+			}
 		}
 	}
 }

--- a/internal/scanner/html_test.go
+++ b/internal/scanner/html_test.go
@@ -23,9 +23,10 @@ func sortedSlice(ss []string) []string {
 
 func TestExtractSlugsFromReader(t *testing.T) {
 	tests := []struct {
-		name      string
-		html      string
-		wantSlugs []string
+		name       string
+		html       string
+		wantSlugs  []string
+		wantThemes []string
 	}{
 		{
 			name: "Single plugin in href",
@@ -64,26 +65,67 @@ func TestExtractSlugsFromReader(t *testing.T) {
 			</body></html>`,
 			wantSlugs: []string{},
 		},
+		{
+			name: "Theme in inline style block",
+			html: `<html><head><style id="wp-webfonts-inline-css">
+				@font-face{font-family:"DM Sans";src:url('/wp-content/themes/twentytwentythree/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');}
+			</style></head><body></body></html>`,
+			wantThemes: []string{"twentytwentythree"},
+		},
+		{
+			name: "Theme in link attribute",
+			html: `<html><head>
+				<link rel="stylesheet" href="/wp-content/themes/flavor/style.css" />
+			</head><body></body></html>`,
+			wantThemes: []string{"flavor"},
+		},
+		{
+			name: "Plugins and themes mixed in attributes and text",
+			html: `<html><head>
+				<link rel="stylesheet" href="/wp-content/plugins/jetpack/css/style.css" />
+				<style>body{background:url('/wp-content/themes/flavor/img/bg.png')}</style>
+			</head><body>
+				<script src="/wp-content/plugins/woocommerce/js/app.js"></script>
+			</body></html>`,
+			wantSlugs:  []string{"jetpack", "woocommerce"},
+			wantThemes: []string{"flavor"},
+		},
+		{
+			name: "Plugin in inline script text",
+			html: `<html><body>
+				<script>var img = "/wp-content/plugins/hidden-plugin/img.png";</script>
+			</body></html>`,
+			wantSlugs: []string{"hidden-plugin"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dest := make(map[string]struct{})
+			plugins := make(map[string]struct{})
 			themes := make(map[string]struct{})
-			err := extractSlugsFromReader(strings.NewReader(tt.html), dest, themes)
+			err := extractSlugsFromReader(strings.NewReader(tt.html), plugins, themes)
 			if err != nil {
 				t.Fatalf("extractSlugsFromReader returned error: %v", err)
 			}
 
-			var got []string
-			for slug := range dest {
-				got = append(got, slug)
+			var gotPlugins []string
+			for slug := range plugins {
+				gotPlugins = append(gotPlugins, slug)
 			}
-			got = sortedSlice(got)
-			want := sortedSlice(tt.wantSlugs)
+			gotPlugins = sortedSlice(gotPlugins)
+			wantPlugins := sortedSlice(tt.wantSlugs)
+			if !reflect.DeepEqual(gotPlugins, wantPlugins) {
+				t.Errorf("plugins = %v, want %v", gotPlugins, wantPlugins)
+			}
 
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("extractSlugsFromReader = %v, want %v", got, want)
+			var gotThemes []string
+			for slug := range themes {
+				gotThemes = append(gotThemes, slug)
+			}
+			gotThemes = sortedSlice(gotThemes)
+			wantThemes := sortedSlice(tt.wantThemes)
+			if !reflect.DeepEqual(gotThemes, wantThemes) {
+				t.Errorf("themes = %v, want %v", gotThemes, wantThemes)
 			}
 		})
 	}


### PR DESCRIPTION
Hi,
The HTML parser (`extractSlugsFromReader`) only processed tag attributes (`href`, `src`, etc.), missing `wp-content/themes/` references embedded in `<style>` or `<script>` text content (e.g. `@font-face` URLs) like :
```
<style id='wp-webfonts-inline-css'>
@font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('/wp-content/themes/twentytwentythree/ [...]
</style>
```

- Added `TextToken` handling with a `wp-content/` pre-filter to avoid unnecessary work on unrelated text nodes
- Added tests covering themes in inline style blocks, mixed plugin/theme discovery, and plugins in inline scripts

Before :
<img width="728" height="381" alt="image" src="https://github.com/user-attachments/assets/dffd06d7-a49c-4c20-afcf-17ceb16a3d33" />

After :
<img width="716" height="435" alt="image" src="https://github.com/user-attachments/assets/ed96cbef-2923-497a-813a-5b76ebbe4f69" />

Regards