### PR TITLE
fix: Hybrid scan dropping themes discovered during stealthy phase

### DIFF
--- a/internal/scanner/modes.go
+++ b/internal/scanner/modes.go
@@ -130,7 +130,9 @@ func performHybridScan(ctx ScanExecutionContext) ScanDetectionResult {
 	stealthyResult := performStealthyScan(ctx)
 
 	if len(stealthyResult.Plugins) == 0 {
-		return performBruteforceScan(ctx)
+		bruteResult := performBruteforceScan(ctx)
+		bruteResult.Themes = stealthyResult.Themes
+		return bruteResult
 	}
 
 	finishProgressIfNeeded(ctx.Progress)

--- a/internal/scanner/modes_test.go
+++ b/internal/scanner/modes_test.go
@@ -1,0 +1,131 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newFakeWPServer(themes []string, plugins []string) *httptest.Server {
+	mux := http.NewServeMux()
+
+	body := "<html><head>"
+	for _, t := range themes {
+		body += fmt.Sprintf(`<link rel="stylesheet" href="/wp-content/themes/%s/style.css">`, t)
+	}
+	for _, p := range plugins {
+		body += fmt.Sprintf(`<script src="/wp-content/plugins/%s/script.js"></script>`, p)
+	}
+	body += "</head><body></body></html>"
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/wp-json" || r.URL.RawQuery == "rest_route=/" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"routes":{}}`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, body)
+	})
+
+	mux.HandleFunc("/feed/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "<html></html>")
+	})
+	mux.HandleFunc("/wp-content/uploads/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "<html></html>")
+	})
+	mux.HandleFunc("/wp-content/", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestPerformHybridScan_PreservesThemesWhenNoPlugins(t *testing.T) {
+	themeName := "theme-alpha"
+	srv := newFakeWPServer([]string{themeName}, nil)
+	defer srv.Close()
+
+	ctx := ScanExecutionContext{
+		Target: srv.URL,
+		Opts: ScanOptions{
+			Threads:  2,
+			ScanMode: "hybrid",
+			File:     "api",
+		},
+		Ctx: context.Background(),
+	}
+
+	result := performHybridScan(ctx)
+
+	if len(result.Themes) == 0 {
+		t.Fatal("expected at least one theme from hybrid scan, got none")
+	}
+
+	found := false
+	for _, theme := range result.Themes {
+		if theme == themeName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected theme %q in results, got: %v", themeName, result.Themes)
+	}
+}
+
+func TestPerformHybridScan_PreservesThemesWithPlugins(t *testing.T) {
+	themeName := "theme-beta"
+	pluginName := "plugin-beta"
+	srv := newFakeWPServer([]string{themeName}, []string{pluginName})
+	defer srv.Close()
+
+	ctx := ScanExecutionContext{
+		Target: srv.URL,
+		Opts: ScanOptions{
+			Threads:  2,
+			ScanMode: "hybrid",
+			File:     "api",
+		},
+		Ctx: context.Background(),
+	}
+
+	result := performHybridScan(ctx)
+
+	if len(result.Themes) == 0 {
+		t.Fatal("expected at least one theme from hybrid scan when plugins exist, got none")
+	}
+
+	foundTheme := false
+	for _, theme := range result.Themes {
+		if theme == themeName {
+			foundTheme = true
+			break
+		}
+	}
+	if !foundTheme {
+		t.Errorf("expected theme %q in results, got: %v", themeName, result.Themes)
+	}
+}
+
+func TestPerformStealthyScan_DiscoversThemes(t *testing.T) {
+	srv := newFakeWPServer([]string{"theme-one", "theme-two"}, nil)
+	defer srv.Close()
+
+	ctx := ScanExecutionContext{
+		Target: srv.URL,
+		Opts: ScanOptions{
+			Threads: 2,
+			File:    "api",
+		},
+		Ctx: context.Background(),
+	}
+
+	result := performStealthyScan(ctx)
+
+	if len(result.Themes) != 2 {
+		t.Fatalf("expected 2 themes, got %d: %v", len(result.Themes), result.Themes)
+	}
+}

--- a/internal/scanner/modes_test.go
+++ b/internal/scanner/modes_test.go
@@ -23,18 +23,18 @@ func newFakeWPServer(themes []string, plugins []string) *httptest.Server {
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/wp-json" || r.URL.RawQuery == "rest_route=/" {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"routes":{}}`)
+			_, _ = fmt.Fprint(w, `{"routes":{}}`)
 			return
 		}
 		w.Header().Set("Content-Type", "text/html")
-		fmt.Fprint(w, body)
+		_, _ = fmt.Fprint(w, body)
 	})
 
 	mux.HandleFunc("/feed/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "<html></html>")
+		_, _ = fmt.Fprint(w, "<html></html>")
 	})
 	mux.HandleFunc("/wp-content/uploads/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "<html></html>")
+		_, _ = fmt.Fprint(w, "<html></html>")
 	})
 	mux.HandleFunc("/wp-content/", func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)


### PR DESCRIPTION
Hi,
Another small fix :)

When hybrid mode's stealthy phase detected themes (via HTML) but no plugins (via REST API), it fell back to `performBruteforceScan()` which returned a fresh result without the themes.

<img width="753" height="1384" alt="image" src="https://github.com/user-attachments/assets/a75afb11-2a0e-4917-9255-67b8c275632b" />

The fix preserves `stealthyResult.Themes` in the bruteforce fallback path, matching the behavior of the normal hybrid path (line 148) which already carried themes forward.

<img width="748" height="1440" alt="image" src="https://github.com/user-attachments/assets/889de001-8916-4675-aa0d-9776baca1094" />

Regards