### PR TITLE
fix: package API returns incomplete scan results

### DIFF
--- a/pkg/build_result_test.go
+++ b/pkg/build_result_test.go
@@ -1,0 +1,101 @@
+package wpprobe
+
+import (
+	"testing"
+
+	"github.com/Chocapikk/wpprobe/internal/file"
+)
+
+func TestBuildResult_IncludesPluginsWithoutVulnerabilities(t *testing.T) {
+	s := &Scanner{}
+	entries := []file.PluginEntry{
+		{Slug: "safe-plugin", SoftwareType: "plugin", Version: "1.0.0"},
+	}
+
+	result := s.buildResult("http://example.com", entries)
+
+	if len(result.Plugins) != 1 {
+		t.Fatalf("expected 1 plugin, got %d", len(result.Plugins))
+	}
+	if result.Plugins[0].Name != "safe-plugin" {
+		t.Errorf("expected plugin name 'safe-plugin', got %q", result.Plugins[0].Name)
+	}
+	if result.TotalVulnerabilities != 0 {
+		t.Errorf("expected 0 vulnerabilities, got %d", result.TotalVulnerabilities)
+	}
+}
+
+func TestBuildResult_IncludesThemesWithoutVulnerabilities(t *testing.T) {
+	s := &Scanner{}
+	entries := []file.PluginEntry{
+		{Slug: "safe-theme", SoftwareType: "theme", Version: "2.0.0"},
+	}
+
+	result := s.buildResult("http://example.com", entries)
+
+	if len(result.Themes) != 1 {
+		t.Fatalf("expected 1 theme, got %d", len(result.Themes))
+	}
+	if result.Themes[0].Name != "safe-theme" {
+		t.Errorf("expected theme name 'safe-theme', got %q", result.Themes[0].Name)
+	}
+}
+
+func TestBuildResult_MixesVulnerableAndSafe(t *testing.T) {
+	s := &Scanner{}
+	entries := []file.PluginEntry{
+		{Slug: "safe-plugin", SoftwareType: "plugin", Version: "1.0.0"},
+		{Slug: "vuln-plugin", SoftwareType: "plugin", Version: "1.2.0",
+			Severity: "high", CVEs: []string{"CVE-2024-1234"}, Title: "RCE", AuthType: "unauth"},
+		{Slug: "safe-theme", SoftwareType: "theme", Version: "3.0.0"},
+	}
+
+	result := s.buildResult("http://example.com", entries)
+
+	if len(result.Plugins) != 2 {
+		t.Fatalf("expected 2 plugins, got %d", len(result.Plugins))
+	}
+	if len(result.Themes) != 1 {
+		t.Fatalf("expected 1 theme, got %d", len(result.Themes))
+	}
+	if result.TotalVulnerabilities != 1 {
+		t.Errorf("expected 1 vulnerability, got %d", result.TotalVulnerabilities)
+	}
+}
+
+func TestBuildResult_SkipsUnknownVersions(t *testing.T) {
+	s := &Scanner{}
+	entries := []file.PluginEntry{
+		{Slug: "no-version", SoftwareType: "plugin", Version: ""},
+		{Slug: "unknown-version", SoftwareType: "plugin", Version: "unknown"},
+		{Slug: "valid", SoftwareType: "plugin", Version: "1.0.0"},
+	}
+
+	result := s.buildResult("http://example.com", entries)
+
+	if len(result.Plugins) != 1 {
+		t.Fatalf("expected 1 plugin, got %d", len(result.Plugins))
+	}
+	if result.Plugins[0].Name != "valid" {
+		t.Errorf("expected plugin name 'valid', got %q", result.Plugins[0].Name)
+	}
+}
+
+func TestBuildResult_DeduplicatesCVEs(t *testing.T) {
+	s := &Scanner{}
+	entries := []file.PluginEntry{
+		{Slug: "plugin-a", SoftwareType: "plugin", Version: "1.0.0",
+			Severity: "critical", CVEs: []string{"CVE-2024-0001"}, Title: "SQLi", AuthType: "unauth"},
+		{Slug: "plugin-a", SoftwareType: "plugin", Version: "1.0.0",
+			Severity: "critical", CVEs: []string{"CVE-2024-0001"}, Title: "SQLi", AuthType: "unauth"},
+	}
+
+	result := s.buildResult("http://example.com", entries)
+
+	if len(result.Plugins) != 1 {
+		t.Fatalf("expected 1 plugin, got %d", len(result.Plugins))
+	}
+	if len(result.Plugins[0].Vulnerabilities.Critical) != 1 {
+		t.Errorf("expected 1 critical vuln (deduped), got %d", len(result.Plugins[0].Vulnerabilities.Critical))
+	}
+}

--- a/pkg/wpprobe.go
+++ b/pkg/wpprobe.go
@@ -272,6 +272,35 @@ func (s *Scanner) buildResult(target string, entries []file.PluginEntry) *ScanRe
 			continue
 		}
 
+		if entry.SoftwareType == "theme" {
+			if _, exists := themeMap[entry.Slug]; !exists {
+				themeMap[entry.Slug] = &ThemeResult{
+					Name:    entry.Slug,
+					Version: entry.Version,
+					Vulnerabilities: VulnerabilitiesBySeverity{
+						Critical: make([]Vulnerability, 0, 4),
+						High:     make([]Vulnerability, 0, 4),
+						Medium:   make([]Vulnerability, 0, 4),
+						Low:      make([]Vulnerability, 0, 4),
+					},
+				}
+			}
+		} else {
+			if _, exists := pluginMap[entry.Slug]; !exists {
+				pluginMap[entry.Slug] = &PluginResult{
+					Name:       entry.Slug,
+					Version:    entry.Version,
+					Confidence: 100.0,
+					Vulnerabilities: VulnerabilitiesBySeverity{
+						Critical: make([]Vulnerability, 0, 4),
+						High:     make([]Vulnerability, 0, 4),
+						Medium:   make([]Vulnerability, 0, 4),
+						Low:      make([]Vulnerability, 0, 4),
+					},
+				}
+			}
+		}
+
 		cve := ""
 		if len(entry.CVEs) > 0 {
 			cve = entry.CVEs[0]
@@ -297,50 +326,17 @@ func (s *Scanner) buildResult(target string, entries []file.PluginEntry) *ScanRe
 		}
 
 		if entry.SoftwareType == "theme" {
-			theme, exists := themeMap[entry.Slug]
-			if !exists {
-				theme = &ThemeResult{
-					Name:    entry.Slug,
-					Version: entry.Version,
-					Vulnerabilities: VulnerabilitiesBySeverity{
-						Critical: make([]Vulnerability, 0, 4),
-						High:     make([]Vulnerability, 0, 4),
-						Medium:   make([]Vulnerability, 0, 4),
-						Low:      make([]Vulnerability, 0, 4),
-					},
-				}
-				themeMap[entry.Slug] = theme
-			}
-			appendVuln(&theme.Vulnerabilities, vuln, &result.Summary)
+			appendVuln(&themeMap[entry.Slug].Vulnerabilities, vuln, &result.Summary)
 		} else {
-			plugin, exists := pluginMap[entry.Slug]
-			if !exists {
-				plugin = &PluginResult{
-					Name:       entry.Slug,
-					Version:    entry.Version,
-					Confidence: 100.0,
-					Vulnerabilities: VulnerabilitiesBySeverity{
-						Critical: make([]Vulnerability, 0, 4),
-						High:     make([]Vulnerability, 0, 4),
-						Medium:   make([]Vulnerability, 0, 4),
-						Low:      make([]Vulnerability, 0, 4),
-					},
-				}
-				pluginMap[entry.Slug] = plugin
-			}
-			appendVuln(&plugin.Vulnerabilities, vuln, &result.Summary)
+			appendVuln(&pluginMap[entry.Slug].Vulnerabilities, vuln, &result.Summary)
 		}
 	}
 
 	for _, p := range pluginMap {
-		if hasVulnerabilities(&p.Vulnerabilities) {
-			result.Plugins = append(result.Plugins, *p)
-		}
+		result.Plugins = append(result.Plugins, *p)
 	}
 	for _, t := range themeMap {
-		if hasVulnerabilities(&t.Vulnerabilities) {
-			result.Themes = append(result.Themes, *t)
-		}
+		result.Themes = append(result.Themes, *t)
 	}
 
 	result.TotalVulnerabilities = result.Summary.Critical + result.Summary.High + result.Summary.Medium + result.Summary.Low

--- a/pkg/wpprobe.go
+++ b/pkg/wpprobe.go
@@ -356,10 +356,6 @@ func appendVuln(vulns *VulnerabilitiesBySeverity, vuln Vulnerability, summary *V
 	}
 }
 
-func hasVulnerabilities(v *VulnerabilitiesBySeverity) bool {
-	return len(v.Critical) > 0 || len(v.High) > 0 || len(v.Medium) > 0 || len(v.Low) > 0
-}
-
 // UpdateDatabases updates both Wordfence and WPScan vulnerability databases.
 // WPScan update requires WPSCAN_API_TOKEN environment variable to be set.
 // Returns an error only if Wordfence update fails. WPScan update failures are ignored

--- a/pkg/wpprobe.go
+++ b/pkg/wpprobe.go
@@ -204,10 +204,6 @@ func (s *Scanner) Scan(cfg Config) (*ScanResult, error) {
 		cfg.Threads = 10
 	}
 
-	if cfg.PluginList == "" {
-		cfg.PluginList = "plugins.txt"
-	}
-
 	maxRedirects := cfg.MaxRedirects
 	if maxRedirects == 0 {
 		maxRedirects = -1 // Use default if not set
@@ -380,10 +376,10 @@ func UpdateDatabases() error {
 	if err := wordfence.UpdateWordfence(); err != nil {
 		return err
 	}
-	
+
 	// WPScan update is optional - try it but don't fail if it errors
 	_ = wpscan.UpdateWPScan()
-	
+
 	return nil
 }
 
@@ -410,4 +406,3 @@ func DatabaseExists() bool {
 	_, err = os.Stat(filePath)
 	return err == nil
 }
-


### PR DESCRIPTION
Hi again :)

- Fix `buildResult()` skipping plugins/themes without CVEs, so `ScanResult` now includes all detected software (matching CLI behavior)
- Fix default `PluginList` in public API using `"plugins.txt"` (nonexistent file) instead of `""` (embedded list)
- Add unit tests for `buildResult` covering: no-vuln inclusion, mixed results, version filtering, CVE dedup

<details>
<summary>Used script for testing</summary

```golang
package main

import (
	"context"
	"fmt"
	"os"
	"strings"

	wpprobe "github.com/Chocapikk/wpprobe/pkg"
)

func main() {
	if len(os.Args) < 2 {
		fmt.Fprintf(os.Stderr, "Usage: %s <target-url>\n", os.Args[0])
		fmt.Fprintf(os.Stderr, "Example: %s https://example.com\n", os.Args[0])
		os.Exit(1)
	}

	scanner, err := wpprobe.New()
	if err != nil {
		fmt.Fprintf(os.Stderr, "Failed to initialize scanner: %v\n", err)
		os.Exit(1)
	}

	target := os.Args[1]
	fmt.Printf("[*] Starting hybrid scan on %s...\n\n", target)

	result, err := scanner.Scan(wpprobe.Config{
		Target:   target,
		ScanMode: "hybrid",
		Threads:  10,
		Context:  context.Background(),
	})
	if err != nil {
		fmt.Fprintf(os.Stderr, "Scan failed: %v\n", err)
		os.Exit(1)
	}

	if len(result.Plugins) == 0 && len(result.Themes) == 0 {
		fmt.Println("[!] No plugins or themes detected.")
		return
	}

	printResults(result)
}

func printResults(result *wpprobe.ScanResult) {
	fmt.Println(strings.Repeat("=", 70))
	fmt.Printf(" PLUGINS (%d detected)\n", len(result.Plugins))
	fmt.Println(strings.Repeat("=", 70))

	for _, p := range result.Plugins {
		vulnCount := countVulns(p.Vulnerabilities)
		if vulnCount == 0 {
			fmt.Printf("  [OK] %s (%s) - No known CVE\n", p.Name, p.Version)
		} else {
			fmt.Printf("  [!!] %s (%s) - %d CVE(s)\n", p.Name, p.Version, vulnCount)
			printVulns(p.Vulnerabilities)
		}
	}

	if len(result.Themes) > 0 {
		fmt.Println()
		fmt.Println(strings.Repeat("=", 70))
		fmt.Printf(" THEMES (%d detected)\n", len(result.Themes))
		fmt.Println(strings.Repeat("=", 70))

		for _, t := range result.Themes {
			vulnCount := countVulns(t.Vulnerabilities)
			if vulnCount == 0 {
				fmt.Printf("  [OK] %s (%s) - No known CVE\n", t.Name, t.Version)
			} else {
				fmt.Printf("  [!!] %s (%s) - %d CVE(s)\n", t.Name, t.Version, vulnCount)
				printVulns(t.Vulnerabilities)
			}
		}
	}

	fmt.Println()
	fmt.Println(strings.Repeat("-", 70))
	fmt.Printf(" Total: %d plugin(s), %d theme(s), %d vulnerability(ies)\n",
		len(result.Plugins), len(result.Themes), result.TotalVulnerabilities)
	fmt.Println(strings.Repeat("-", 70))
}

func printVulns(vulns wpprobe.VulnerabilitiesBySeverity) {
	all := append(vulns.Critical, vulns.High...)
	all = append(all, vulns.Medium...)
	all = append(all, vulns.Low...)

	for _, v := range all {
		cve := v.CVE
		if cve == "" {
			cve = "N/A"
		}
		title := v.Title
		if len(title) > 50 {
			title = title[:47] + "..."
		}
		fmt.Printf("       - [%s] %s | %s | Auth: %s\n",
			strings.ToUpper(v.Severity), cve, title, v.AuthType)
	}
}

func countVulns(v wpprobe.VulnerabilitiesBySeverity) int {
	return len(v.Critical) + len(v.High) + len(v.Medium) + len(v.Low)
}
```
</details>

Before (The theme is not present) : 
<img width="799" height="722" alt="image" src="https://github.com/user-attachments/assets/0bdcfef0-5d51-475c-a9bb-b36feb45b483" />

After : 
<img width="787" height="833" alt="image" src="https://github.com/user-attachments/assets/7b864b1b-533e-4e16-82d9-b236dfaedb70" />

Regards