### PR TITLE
Improve hybrid scanning, WAF calibration, and CLI progress output

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -89,6 +89,13 @@ var scanCmd = &cobra.Command{
 
 		rateLimit := mustInt(cmd.Flags().GetInt("rate-limit"))
 
+		pluginList := cmd.Flag("plugin-list").Value.String()
+
+		scanMode, err := resolveScanMode(cmd.Flag("mode").Value.String(), pluginList, cmd.Flags().Changed("mode"))
+		if err != nil {
+			return err
+		}
+
 		opts := scanner.ScanOptions{
 			URL:            cmd.Flag("url").Value.String(),
 			File:           cmd.Flag("file").Value.String(),
@@ -97,8 +104,8 @@ var scanCmd = &cobra.Command{
 			Output:         outputFile,
 			OutputFormat:   outputFormat,
 			Verbose:        mustBool(cmd.Flags().GetBool("verbose")),
-			ScanMode:       cmd.Flag("mode").Value.String(),
-			PluginList:     cmd.Flag("plugin-list").Value.String(),
+			ScanMode:       scanMode,
+			PluginList:     pluginList,
 			Headers:        headers,
 			Proxy:          proxyURL,
 			RateLimit:      rateLimit,
@@ -132,6 +139,26 @@ func init() {
 	scanCmd.Flags().String("proxy", "", "HTTP/HTTPS proxy URL (e.g., http://127.0.0.1:8080)")
 	scanCmd.Flags().
 		Int("rate-limit", 50, "Maximum requests per second (0 = unlimited). Default 50 to avoid flooding network.")
+}
+
+func resolveScanMode(mode, pluginList string, modeExplicit bool) (string, error) {
+    if strings.TrimSpace(pluginList) == "" {
+        return mode, nil
+    }
+
+	// If a plugin list is provided without an explicit mode, automatically use
+	// hybrid mode: HTML/REST detection followed by brute-force.
+    if !modeExplicit {
+        return "hybrid", nil
+    }
+
+    // A plugin list cannot be used in stealthy mode.
+    if mode == "stealthy" {
+        return "",
+		fmt.Errorf("--plugin-list/-p requires --mode bruteforce or --mode hybrid")
+    }
+
+    return mode, nil
 }
 
 func mustBool(value bool, err error) bool {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -98,6 +98,12 @@ func FormatSuccess(msg string) string {
 	return formatTime() + " [" + colorize(ansiSuccess, "SUCCESS") + "] " + msg
 }
 
+// FormatInfo returns a formatted info message without printing it, allowing
+// callers to route the line cleanly above an active progress bar.
+func FormatInfo(msg string) string {
+	return formatTime() + " [" + colorize(ansiInfo, "INFO") + "] " + msg
+}
+
 // FormatWarning returns a formatted warning message string without printing it,
 // so callers can route it through an active progress bar (which otherwise eats a
 // plain logger write) instead of the logger.

--- a/internal/scanner/bruteforce.go
+++ b/internal/scanner/bruteforce.go
@@ -199,13 +199,10 @@ func scanPlugin(plugin string, ctx BruteforceContext) {
 		return
 	}
 
-	// A WAF may return 403 for one candidate file and a generated readme for an
-	// absent plugin. Never retain or display the slug when that readme matches
-	// the calibrated deceptive template by at least the configured threshold.
-	if ctx.Calibrator.IsPluginDeceptive(ctx.Ctx, ctx.Client, ctx.Target, plugin) {
-		incrementProgress(ctx.Progress)
-		return
-	}
+	// Deceptive-template suppression (a host serving a generated readme for any
+	// slug) is handled once, post-scan, in FilterDeceptiveResults, which only
+	// re-probes when calibration actually flagged a deceptive WAF. Doing it here
+	// too would re-probe every found plugin on every host, deceptive or not.
 
 	// A bare 403 is ambiguous: a plugin hardened with its own .htaccess and a WAF
 	// forbidding the slug for a plugin that is NOT installed look identical here

--- a/internal/scanner/bruteforce.go
+++ b/internal/scanner/bruteforce.go
@@ -77,7 +77,10 @@ func BruteforcePlugins(req BruteforceRequest) ([]string, map[string]string) {
 
 	// Learn what a request for a non-existent plugin file looks like on this
 	// target, so detection works regardless of the web server and its config.
-	calibrator := NewCalibrator(ctx, sharedClient, normalized)
+	calibrator := req.Calibrator
+	if calibrator == nil {
+		calibrator = NewCalibrator(ctx, sharedClient, normalized)
+	}
 
 	bruteCtx := BruteforceContext{
 		ScanContext: ScanContext{
@@ -186,16 +189,20 @@ func scanPlugin(plugin string, ctx BruteforceContext) {
 	default:
 	}
 
-	if ctx.Progress != nil {
-		ctx.Progress.SetMessage(fmt.Sprintf("Bruteforcing plugin %-30.30s", plugin))
-	}
-
 	// Phase 1: confirm the plugin is present on disk by probing the files it
 	// ships (issue #27). A response that differs from the calibrated miss
 	// baseline confirms the plugin, even when it is installed but not activated
 	// (which the stealthy scan misses) and regardless of the web server config.
 	found, status := probePluginFiles(ctx, plugin, candidateFiles(plugin, ctx.Fingerprints))
 	if !found {
+		incrementProgress(ctx.Progress)
+		return
+	}
+
+	// A WAF may return 403 for one candidate file and a generated readme for an
+	// absent plugin. Never retain or display the slug when that readme matches
+	// the calibrated deceptive template by at least the configured threshold.
+	if ctx.Calibrator.IsPluginDeceptive(ctx.Ctx, ctx.Client, ctx.Target, plugin) {
 		incrementProgress(ctx.Progress)
 		return
 	}
@@ -275,10 +282,12 @@ func probePluginFiles(ctx BruteforceContext, plugin string, files []string) (boo
 
 func recordPluginFound(plugin, ver string, ctx BruteforceContext) {
 	msg := "Found plugin " + plugin + " version " + ver
-	if ctx.Progress != nil {
-		_, _ = ctx.Progress.Bprintln(logger.FormatSuccess(msg))
-	} else {
-		logger.DefaultLogger.Success(msg)
+	if logger.DefaultLogger.Verbose {
+		if ctx.Progress != nil {
+			_, _ = ctx.Progress.Bprintln(logger.FormatSuccess(msg))
+		} else {
+			logger.DefaultLogger.Success(msg)
+		}
 	}
 
 	ctx.Mu.Lock()

--- a/internal/scanner/calibration.go
+++ b/internal/scanner/calibration.go
@@ -21,8 +21,15 @@ package scanner
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
 
 	"github.com/Chocapikk/wpprobe/internal/http"
+	"github.com/Chocapikk/wpprobe/internal/logger"
 )
 
 // probeBodyCap is how many bytes of a response body we fingerprint. The head of
@@ -40,21 +47,21 @@ type responseSig struct {
 	bodyHash uint64
 }
 
-func asciiLower(c byte) byte {
-	if c >= 'A' && c <= 'Z' {
-		return c + 32
+func asciiLower(character byte) byte {
+	if character >= 'A' && character <= 'Z' {
+		return character + 32
 	}
-	return c
+	return character
 }
 
 // matchFold reports whether s, starting at pos, begins with token (token must
 // already be lowercase), comparing ASCII case-insensitively.
-func matchFold(s string, pos int, token string) bool {
-	if pos+len(token) > len(s) {
+func matchFold(input string, position int, token string) bool {
+	if position+len(token) > len(input) {
 		return false
 	}
-	for i := 0; i < len(token); i++ {
-		if asciiLower(s[pos+i]) != token[i] {
+	for tokenIndex := 0; tokenIndex < len(token); tokenIndex++ {
+		if asciiLower(input[position+tokenIndex]) != token[tokenIndex] {
 			return false
 		}
 	}
@@ -63,10 +70,10 @@ func matchFold(s string, pos int, token string) bool {
 
 // indexFold returns the first index >= pos where token (lowercase) occurs in s,
 // case-insensitively, or -1.
-func indexFold(s string, pos int, token string) int {
-	for ; pos+len(token) <= len(s); pos++ {
-		if matchFold(s, pos, token) {
-			return pos
+func indexFold(input string, position int, token string) int {
+	for ; position+len(token) <= len(input); position++ {
+		if matchFold(input, position, token) {
+			return position
 		}
 	}
 	return -1
@@ -94,31 +101,31 @@ const (
 // string is built, the bytes are folded straight into the hash. A
 // strings.Builder + regex version was ~18x slower at 26 allocations; this path
 // runs once per probe on soft-404 hosts.
-func normalizedHash(s string) uint64 {
+func normalizedHash(input string) uint64 {
 	hash := uint64(fnvOffset64)
-	mix := func(c byte) {
-		hash ^= uint64(c)
+	mix := func(character byte) {
+		hash ^= uint64(character)
 		hash *= fnvPrime64
 	}
 
 	emitted, pendingSpace, lastDigit := false, false, false
-	for i, n := 0, len(s); i < n; {
-		c := s[i]
-		if c == '<' {
-			if matchFold(s, i, "<script") {
-				if end := indexFold(s, i+7, "</script>"); end >= 0 {
-					i = end + len("</script>")
+	for position, inputLength := 0, len(input); position < inputLength; {
+		character := input[position]
+		if character == '<' {
+			if matchFold(input, position, "<script") {
+				if end := indexFold(input, position+7, "</script>"); end >= 0 {
+					position = end + len("</script>")
 				} else {
-					i = n
+					position = inputLength
 				}
 				lastDigit = false
 				continue
 			}
-			if matchFold(s, i, "<!--") {
-				if end := indexFold(s, i+4, "-->"); end >= 0 {
-					i = end + len("-->")
+			if matchFold(input, position, "<!--") {
+				if end := indexFold(input, position+4, "-->"); end >= 0 {
+					position = end + len("-->")
 				} else {
-					i = n
+					position = inputLength
 				}
 				lastDigit = false
 				continue
@@ -126,10 +133,10 @@ func normalizedHash(s string) uint64 {
 		}
 
 		switch {
-		case c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v':
+		case character == ' ' || character == '\t' || character == '\n' || character == '\r' || character == '\f' || character == '\v':
 			pendingSpace = emitted // ignore leading whitespace; trailing never flushes
 			lastDigit = false
-		case c >= '0' && c <= '9':
+		case character >= '0' && character <= '9':
 			if pendingSpace {
 				mix(' ')
 				pendingSpace = false
@@ -144,10 +151,10 @@ func normalizedHash(s string) uint64 {
 				mix(' ')
 				pendingSpace = false
 			}
-			mix(c)
+			mix(character)
 			emitted, lastDigit = true, false
 		}
-		i++
+		position++
 	}
 
 	return hash
@@ -179,10 +186,54 @@ type Calibrator struct {
 	// missSigs are exact (status, normalized-bodyHash) shapes seen for absent
 	// paths. Only consulted for ambiguous statuses (see bodyAmbiguous).
 	missSigs map[responseSig]struct{}
-	// missStatusOnly holds statuses whose body varies per request (e.g. a 404
-	// page that echoes the requested path); for those we match on status alone.
-	missStatusOnly map[int]struct{}
-	available      bool
+	// missBodies holds the ambiguous response bodies collected during
+	// calibration. Near-matches are treated as misses, which catches deceptive
+	// readmes whose slug or fake version changes on every request.
+	missBodies   map[int][]string
+	deceptiveWAF bool
+	available    bool
+}
+
+const missBodySimilarityThreshold = 0.70
+
+// bodySimilarity returns the Sørensen-Dice similarity of two response bodies.
+// Tokens are compared as a multiset so small changes in paths, generated
+// versions, timestamps, or ordering do not prevent a deceptive template from
+// matching its calibration baseline.
+func bodySimilarity(candidateBody, calibrationBody string) float64 {
+	candidateTokens := strings.Fields(strings.ToLower(candidateBody))
+	calibrationTokens := strings.Fields(strings.ToLower(calibrationBody))
+	if len(candidateTokens) == 0 || len(calibrationTokens) == 0 {
+		if len(candidateTokens) == len(calibrationTokens) {
+			return 1
+		}
+		return 0
+	}
+
+	candidateTokenCounts := make(map[string]int, len(candidateTokens))
+	for _, candidateToken := range candidateTokens {
+		candidateTokenCounts[similarityToken(candidateToken)]++
+	}
+
+	commonTokenCount := 0
+	for _, calibrationToken := range calibrationTokens {
+		calibrationToken = similarityToken(calibrationToken)
+		if candidateTokenCounts[calibrationToken] > 0 {
+			commonTokenCount++
+			candidateTokenCounts[calibrationToken]--
+		}
+	}
+
+	return float64(2*commonTokenCount) / float64(len(candidateTokens)+len(calibrationTokens))
+}
+
+func similarityToken(token string) string {
+	// Echoed request paths are the most common source of otherwise identical
+	// soft-404 bodies differing during calibration.
+	if strings.Contains(token, "/") {
+		return "#path"
+	}
+	return token
 }
 
 // bodyAmbiguous reports whether a "not found" status could also be returned by a
@@ -194,66 +245,92 @@ func bodyAmbiguous(status int) bool {
 	return status == 200 || status == 403 || status == 500
 }
 
-// calibrationPaths are random, almost-certainly-absent plugin paths. Two
-// distinct slugs are used so we can tell a stable miss page from one that
-// echoes the requested path. Both file types are covered because a missing
-// .php and a missing static file can behave differently (see nginx above).
-var calibrationPaths = []string{
-	"wpprobe-calib-a9f3e1d7/wpprobe-calib-a9f3e1d7.php",
-	"wpprobe-calib-a9f3e1d7/readme.txt",
-	"wpprobe-calib-7c02bd54/index.php",
-	"wpprobe-calib-7c02bd54/readme.txt",
+const calibrationAttempts = 5
+
+// newCalibrationPaths returns the almost-certainly-absent plugin files used by
+// the brute-force probe. Each path is calibrated independently because a web
+// server or WAF may handle PHP files and readme filename casing differently.
+func newCalibrationPaths() []string {
+	slug := randomCalibrationSlug()
+	return []string{
+		slug + "/readme.txt",
+		slug + "/Readme.txt",
+		slug + "/" + slug + ".php",
+	}
 }
 
-// NewCalibrator probes the target with the known-absent paths and records the
-// resulting response signatures as the miss baseline.
+var calibrationFallbackCounter uint64
+
+func randomCalibrationSlug() string {
+	random := make([]byte, 4)
+	if _, err := rand.Read(random); err != nil {
+		// A collision remains extremely unlikely even when the OS random source
+		// is unavailable; the prefix itself is deliberately non-plugin-like.
+		return fmt.Sprintf(
+			"no-existing-plugin-%x-%x",
+			normalizedHash(err.Error()),
+			atomic.AddUint64(&calibrationFallbackCounter, 1),
+		)
+	}
+	return "no-existing-plugin-" + hex.EncodeToString(random)
+}
+
+// NewCalibrator probes each known-absent candidate several times because a WAF
+// may alternate between 404, 403, and a deceptive 200 response. Calibration
+// stops as soon as a 200 response containing a Stable tag field is found, with
+// calibrationAttempts * len(newCalibrationPaths()) as the maximum request count.
 func NewCalibrator(ctx context.Context, client *http.HTTPClientManager, target string) *Calibrator {
-	c := &Calibrator{
-		missStatuses:   make(map[int]struct{}),
-		missSigs:       make(map[responseSig]struct{}, len(calibrationPaths)),
-		missStatusOnly: make(map[int]struct{}),
+	calibrator := &Calibrator{
+		missStatuses: make(map[int]struct{}),
+		missSigs:     make(map[responseSig]struct{}, len(newCalibrationPaths())),
+		missBodies:   make(map[int][]string),
 	}
 	base := target + "/wp-content/plugins/"
-	bodiesByStatus := make(map[int]map[uint64]struct{})
+	calibrationPaths := newCalibrationPaths()
+	fallbackOKBodies := make([]string, 0, calibrationAttempts*len(calibrationPaths))
 
-	for _, p := range calibrationPaths {
-		select {
-		case <-ctx.Done():
-			return c
-		default:
+	for _, calibrationPath := range calibrationPaths {
+		for attempt := 0; attempt < calibrationAttempts; attempt++ {
+			select {
+			case <-ctx.Done():
+				return calibrator
+			default:
+			}
+			status, body, err := client.ProbeNoRedirect(ctx, base+calibrationPath, probeBodyCap)
+			if err != nil {
+				continue
+			}
+			calibrator.available = true
+			calibrator.missStatuses[status] = struct{}{}
+			// Only ambiguous statuses ever need the body hash; skip the work otherwise.
+			if !bodyAmbiguous(status) {
+				continue
+			}
+			if status == 200 {
+				if !strings.Contains(strings.ToLower(body), "stable tag:") {
+					fallbackOKBodies = append(fallbackOKBodies, body)
+					continue
+				}
+				calibrator.missSigs[signature(200, body)] = struct{}{}
+				calibrator.missBodies[200] = append(calibrator.missBodies[200], body)
+				calibrator.deceptiveWAF = true
+				return calibrator
+			}
+			sig := signature(status, body)
+			calibrator.missSigs[sig] = struct{}{}
+			calibrator.missBodies[status] = append(calibrator.missBodies[status], body)
 		}
-		status, body, err := client.ProbeNoRedirect(ctx, base+p, probeBodyCap)
-		if err != nil {
-			continue
-		}
-		c.available = true
-		c.missStatuses[status] = struct{}{}
-		// Only ambiguous statuses ever need the body hash; skip the work otherwise.
-		if !bodyAmbiguous(status) {
-			continue
-		}
-		sig := signature(status, body)
-		c.missSigs[sig] = struct{}{}
-		if bodiesByStatus[status] == nil {
-			bodiesByStatus[status] = make(map[uint64]struct{})
-		}
-		bodiesByStatus[status][sig.bodyHash] = struct{}{}
 	}
-
-	// If a status produced more than one distinct body across the two slugs, its
-	// body is path-dependent (it echoes the request), so the exact hash is
-	// useless: match that status on the status code alone.
-	for status, hashes := range bodiesByStatus {
-		if len(hashes) > 1 {
-			c.missStatusOnly[status] = struct{}{}
-		}
+	for _, fallbackOKBody := range fallbackOKBodies {
+		calibrator.missSigs[signature(200, fallbackOKBody)] = struct{}{}
+		calibrator.missBodies[200] = append(calibrator.missBodies[200], fallbackOKBody)
 	}
-	return c
+	return calibrator
 }
 
 // IsInstalled reports whether a probe response indicates the file exists on
 // disk, i.e. its signature does not match any calibrated miss.
-func (c *Calibrator) IsInstalled(status int, body string) bool {
+func (calibrator *Calibrator) IsInstalled(status int, body string) bool {
 	// A redirect is never a served file: the web server is rerouting the
 	// request, not serving content from the plugin directory. This catches
 	// hosts where calibration returns 404 but a WAF or reverse proxy returns
@@ -261,7 +338,7 @@ func (c *Calibrator) IsInstalled(status int, body string) bool {
 	if status >= 300 && status < 400 {
 		return false
 	}
-	if !c.available {
+	if !calibrator.available {
 		// Calibration failed (e.g. target unreachable during calibration): fall
 		// back to "served or hardened" - a file that is served (200) or exists
 		// but is access-denied (403).
@@ -269,7 +346,7 @@ func (c *Calibrator) IsInstalled(status int, body string) bool {
 	}
 	// Fast path: a status the server never used for "not found" means the file
 	// was served or executed. No body work for the common 200/403 hit.
-	if _, isMiss := c.missStatuses[status]; !isMiss {
+	if _, isMiss := calibrator.missStatuses[status]; !isMiss {
 		return true
 	}
 	// The status is a "not found" status. If a served file could not have
@@ -277,9 +354,97 @@ func (c *Calibrator) IsInstalled(status int, body string) bool {
 	if !bodyAmbiguous(status) {
 		return false
 	}
-	if _, ok := c.missStatusOnly[status]; ok {
+	if _, isMiss := calibrator.missSigs[signature(status, body)]; isMiss {
 		return false
 	}
-	_, isMiss := c.missSigs[signature(status, body)]
-	return !isMiss
+	for _, missBody := range calibrator.missBodies[status] {
+		if bodySimilarity(body, missBody) >= missBodySimilarityThreshold {
+			return false
+		}
+	}
+	return true
+}
+
+// IsDeceptiveBody reports whether a response body matches any calibrated miss
+// template, regardless of the HTTP status that originally returned it. This is
+// used as a final guard when a WAF confirms one candidate file with 403 but
+// serves a deceptive readme with 200 for the same nonexistent plugin.
+func (calibrator *Calibrator) IsDeceptiveBody(body string) bool {
+	for _, missBodies := range calibrator.missBodies {
+		for _, missBody := range missBodies {
+			if bodySimilarity(body, missBody) >= missBodySimilarityThreshold {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (calibrator *Calibrator) HasDeceptiveWAF() bool {
+	return calibrator.deceptiveWAF
+}
+
+func (calibrator *Calibrator) IsPluginDeceptive(
+	ctx context.Context,
+	client *http.HTTPClientManager,
+	target string,
+	plugin string,
+) bool {
+	base := target + "/wp-content/plugins/" + plugin + "/"
+	for _, readmeName := range []string{"readme.txt", "Readme.txt"} {
+		for attempt := 0; attempt < calibrationAttempts; attempt++ {
+			status, body, err := client.ProbeNoRedirect(ctx, base+readmeName, probeBodyCap)
+			if err != nil || status != 200 {
+				continue
+			}
+			if calibrator.IsDeceptiveBody(body) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func NewScanCalibrator(ctx context.Context, target string, opts ScanOptions) *Calibrator {
+	if opts.Calibrator != nil {
+		return opts.Calibrator
+	}
+	normalizedTarget := http.NormalizeURL(target)
+	client := HTTPConfigFromOpts(opts).NewClient(10 * time.Second)
+	return NewCalibrator(ctx, client, normalizedTarget)
+}
+
+func DisplayDeceptiveWAFWarning(progress Progress) {
+	message := "A deceptive WAF response was detected during calibration; plugin results matching the fake readme template are suppressed."
+	if progress != nil {
+		_, _ = progress.Bprintln(logger.FormatWarning(message))
+		return
+	}
+	logger.DefaultLogger.Logger.Println(logger.FormatWarning(message))
+}
+
+func FilterDeceptiveResults(ctx ScanExecutionContext, result ScanDetectionResult) ScanDetectionResult {
+	if len(result.Plugins) == 0 {
+		return result
+	}
+
+	target := http.NormalizeURL(ctx.Target)
+	client := HTTPConfigFromOpts(ctx.Opts).NewClient(10 * time.Second)
+	calibrator := NewScanCalibrator(ctx.Ctx, target, ctx.Opts)
+	if !calibrator.HasDeceptiveWAF() {
+		return result
+	}
+
+	filteredPlugins := make([]string, 0, len(result.Plugins))
+	for _, plugin := range result.Plugins {
+		if calibrator.IsPluginDeceptive(ctx.Ctx, client, target, plugin) {
+			delete(result.PluginResult.Plugins, plugin)
+			delete(result.Versions, plugin)
+			continue
+		}
+		filteredPlugins = append(filteredPlugins, plugin)
+	}
+	result.Plugins = filteredPlugins
+	result.PluginResult.Detected = filteredPlugins
+	return result
 }

--- a/internal/scanner/calibration_bench_test.go
+++ b/internal/scanner/calibration_bench_test.go
@@ -37,7 +37,6 @@ func apacheLikeCalibrator() *Calibrator {
 	return &Calibrator{
 		missStatuses:   map[int]struct{}{301: {}},
 		missSigs:       map[responseSig]struct{}{},
-		missStatusOnly: map[int]struct{}{},
 		available:      true,
 	}
 }
@@ -46,7 +45,6 @@ func softNotFoundCalibrator() *Calibrator {
 	c := &Calibrator{
 		missStatuses:   map[int]struct{}{200: {}},
 		missSigs:       map[responseSig]struct{}{},
-		missStatusOnly: map[int]struct{}{},
 		available:      true,
 	}
 	c.missSigs[signature(200, benchBody)] = struct{}{}

--- a/internal/scanner/calibration_similarity_test.go
+++ b/internal/scanner/calibration_similarity_test.go
@@ -212,3 +212,62 @@ func TestNewCalibratorDeceptiveWAF(t *testing.T) {
 		t.Error("a response matching the deceptive template must be suppressed (miss)")
 	}
 }
+
+// The deceptive-suppression threshold is a heuristic, and its whole safety rests
+// on the margin between "two genuinely different plugin readmes" and "the same
+// deceptive template served for a different slug/version". This test brackets
+// missBodySimilarityThreshold so the margin cannot be silently broken:
+//
+//   - Lowering it (to "catch more") until a real plugin's readme scores above it
+//     would suppress real plugins as deceptive (false negatives). Real, distinct
+//     readmes must stay BELOW the threshold.
+//   - Raising it until a per-request template variant scores below it would let
+//     the deceptive WAF response through (false positives). A near-duplicate
+//     template must stay AT or ABOVE the threshold.
+//
+// Measured values at time of writing: two real readmes ~0.36, real vs deceptive
+// template ~0.42-0.44, near-duplicate template ~0.93.
+func TestDeceptiveSuppressionMargin(t *testing.T) {
+	realA := "=== Contact Form 7 ===\n" +
+		"Contributors: takayukister\n" +
+		"Tags: contact, form, feedback, email, ajax\n" +
+		"Requires at least: 6.0\nTested up to: 6.4\nStable tag: 5.8.4\n" +
+		"License: GPLv2 or later\n== Description ==\n" +
+		"Just another contact form plugin. Simple but flexible. Contact Form 7 " +
+		"can manage multiple contact forms, plus you can customize the form and " +
+		"the mail contents flexibly with simple markup."
+	realB := "=== Yoast SEO ===\n" +
+		"Contributors: yoast, joostdevalk, tacoverdo\n" +
+		"Tags: SEO, XML sitemap, content analysis, readability, schema\n" +
+		"Requires at least: 6.2\nTested up to: 6.4\nStable tag: 21.7\n" +
+		"License: GPLv3\n== Description ==\n" +
+		"Improve your WordPress SEO: write better content and have a fully " +
+		"optimized WordPress site using the Yoast SEO plugin."
+	deceptive := "=== Plugin ===\n" +
+		"Contributors: admin\nTags: wordpress, plugin\n" +
+		"Requires at least: 5.0\nTested up to: 6.4\nStable tag: 1.0.0\n" +
+		"License: GPLv2 or later\n== Description ==\n" +
+		"This plugin is installed and active on this site."
+	// Same template, only the per-request slug/version differs.
+	deceptiveVariant := "=== Plugin ===\n" +
+		"Contributors: admin\nTags: wordpress, plugin\n" +
+		"Requires at least: 5.0\nTested up to: 6.4\nStable tag: 9.9.9\n" +
+		"License: GPLv2 or later\n== Description ==\n" +
+		"This plugin is installed and active on this site."
+
+	// Real plugins must NOT be suppressed: they stay below the threshold.
+	if s := bodySimilarity(realA, realB); s >= missBodySimilarityThreshold {
+		t.Errorf("two genuine readmes scored %.3f >= threshold %.2f: lowering the "+
+			"threshold this far would suppress real plugins", s, missBodySimilarityThreshold)
+	}
+	if s := bodySimilarity(realA, deceptive); s >= missBodySimilarityThreshold {
+		t.Errorf("a real readme vs the deceptive template scored %.3f >= threshold %.2f: "+
+			"real plugins on a deceptive-WAF host would be hidden", s, missBodySimilarityThreshold)
+	}
+
+	// Deceptive template variants MUST be suppressed: they stay at/above threshold.
+	if s := bodySimilarity(deceptive, deceptiveVariant); s < missBodySimilarityThreshold {
+		t.Errorf("a per-request variant of the deceptive template scored %.3f < threshold "+
+			"%.2f: raising the threshold this high would let the fake WAF readme through", s, missBodySimilarityThreshold)
+	}
+}

--- a/internal/scanner/calibration_similarity_test.go
+++ b/internal/scanner/calibration_similarity_test.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2025 Valentin Lobstein (Chocapikk) <balgogan@protonmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package scanner
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	wphttp "github.com/Chocapikk/wpprobe/internal/http"
+)
+
+// bodySimilarity is the Sørensen-Dice coefficient used to recognise deceptive
+// WAF templates whose paths / generated versions vary per request.
+func TestBodySimilarity(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want float64
+	}{
+		{"identical", "a b c", "a b c", 1},
+		{"disjoint", "a b c", "x y z", 0},
+		{"both empty", "", "", 1},
+		{"one empty", "", "a", 0},
+		{"case insensitive", "Foo BAR", "foo bar", 1},
+		{"echoed path collapses", "nope at /a/readme.txt", "nope at /b/foo.php", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bodySimilarity(tt.a, tt.b); got != tt.want {
+				t.Errorf("bodySimilarity(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+
+	// The coefficient must land on the correct side of the suppression
+	// threshold: a near-duplicate (one differing token out of many) is above it,
+	// a mostly-different body is below it.
+	near := bodySimilarity(
+		"=== Plugin === stable tag: 1.0.0 contributors alice description here",
+		"=== Plugin === stable tag: 9.9.9 contributors alice description here",
+	)
+	if near < missBodySimilarityThreshold {
+		t.Errorf("near-duplicate similarity %.3f should be >= threshold %.2f", near, missBodySimilarityThreshold)
+	}
+	far := bodySimilarity(
+		"=== Plugin === stable tag: 1.0.0 contributors alice",
+		"completely unrelated lorem ipsum dolor sit amet consectetur",
+	)
+	if far >= missBodySimilarityThreshold {
+		t.Errorf("unrelated similarity %.3f should be < threshold %.2f", far, missBodySimilarityThreshold)
+	}
+}
+
+// Echoed request paths are the main source of otherwise-identical soft-404
+// bodies differing between probes, so they are folded to a single token.
+func TestSimilarityToken(t *testing.T) {
+	if got := similarityToken("/no-existing-plugin/readme.txt"); got != "#path" {
+		t.Errorf("path token = %q, want %q", got, "#path")
+	}
+	if got := similarityToken("contributors"); got != "contributors" {
+		t.Errorf("plain token = %q, want unchanged", got)
+	}
+}
+
+// Only 200/403/500 can be produced by BOTH a served file and a "not found"
+// response, so only those ever justify hashing the body.
+func TestBodyAmbiguous(t *testing.T) {
+	for _, s := range []int{200, 403, 500} {
+		if !bodyAmbiguous(s) {
+			t.Errorf("status %d must be ambiguous", s)
+		}
+	}
+	for _, s := range []int{301, 302, 304, 404, 410, 502} {
+		if bodyAmbiguous(s) {
+			t.Errorf("status %d must not be ambiguous", s)
+		}
+	}
+}
+
+// normalizedHash neutralises the parts of a page that legitimately vary between
+// two identical requests, so a dynamic "not found" page keeps a stable
+// fingerprint: inline scripts and comments are dropped, digit runs collapse, and
+// whitespace runs collapse.
+func TestNormalizedHashNeutralizesVolatility(t *testing.T) {
+	equal := []struct {
+		name string
+		a, b string
+	}{
+		{"digit runs collapse", "error ref 1 at 170001", "error ref 9999 at 17000099999"},
+		{"inline script dropped", "head<script>var n=1</script>tail", "head<script>anything else</script>tail"},
+		{"html comment dropped", "head<!-- gen 1 -->tail", "head<!-- gen 99999 -->tail"},
+		{"whitespace runs collapse", "a   b\n\t c", "a b c"},
+	}
+	for _, tt := range equal {
+		t.Run(tt.name, func(t *testing.T) {
+			if normalizedHash(tt.a) != normalizedHash(tt.b) {
+				t.Errorf("normalizedHash should treat %q and %q as equal", tt.a, tt.b)
+			}
+		})
+	}
+
+	// Genuinely different content must still hash differently, or a served file
+	// would be mistaken for the miss baseline.
+	if normalizedHash("=== Real Plugin ===\nStable tag: 1.2.3") == normalizedHash("<html><head><title>not found</title></head>") {
+		t.Error("distinct bodies must not collide after normalization")
+	}
+}
+
+// The calibration slug is deliberately non-plugin-like and the three probe paths
+// cover both readme casings and the plugin PHP file.
+func TestNewCalibrationPaths(t *testing.T) {
+	paths := newCalibrationPaths()
+	if len(paths) != 3 {
+		t.Fatalf("expected 3 calibration paths, got %d: %v", len(paths), paths)
+	}
+	slug := strings.SplitN(paths[0], "/", 2)[0]
+	if !strings.HasPrefix(slug, "no-existing-plugin-") {
+		t.Errorf("slug %q must carry the non-plugin-like prefix", slug)
+	}
+	if paths[0] != slug+"/readme.txt" ||
+		paths[1] != slug+"/Readme.txt" ||
+		paths[2] != slug+"/"+slug+".php" {
+		t.Errorf("unexpected calibration path shape: %v", paths)
+	}
+}
+
+// A constructed calibrator must treat a body that is similar enough to a
+// calibrated miss template as a miss (deceptive readme whose version/path
+// changes per request), while a clearly different served body stays a hit.
+func TestCalibratorSimilarityMiss(t *testing.T) {
+	template := "=== Fake Plugin === stable tag: 1.0.0 contributors waf served for any slug"
+	c := &Calibrator{
+		missStatuses: map[int]struct{}{200: {}},
+		missSigs:     map[responseSig]struct{}{},
+		missBodies:   map[int][]string{200: {template}},
+		available:    true,
+	}
+
+	deceptiveVariant := "=== Fake Plugin === stable tag: 9.9.9 contributors waf served for any slug"
+	if c.IsInstalled(200, deceptiveVariant) {
+		t.Error("a per-request variant of the deceptive template must be a miss")
+	}
+	realPlugin := "wordpress plugin bootstrap file totally unrelated content here"
+	if !c.IsInstalled(200, realPlugin) {
+		t.Error("a genuinely different served body must be a hit")
+	}
+}
+
+// IsDeceptiveBody matches a body against every calibrated miss template
+// regardless of the status that produced it.
+func TestIsDeceptiveBody(t *testing.T) {
+	template := "=== Fake Plugin === stable tag: 1.0.0 contributors waf served for any slug"
+	c := &Calibrator{
+		missStatuses: map[int]struct{}{},
+		missSigs:     map[responseSig]struct{}{},
+		missBodies:   map[int][]string{403: {template}},
+		available:    true,
+	}
+	if !c.IsDeceptiveBody("=== Fake Plugin === stable tag: 7.7.7 contributors waf served for any slug") {
+		t.Error("a variant of the deceptive template must be reported as deceptive")
+	}
+	if c.IsDeceptiveBody("completely unrelated lorem ipsum dolor sit amet") {
+		t.Error("an unrelated body must not be reported as deceptive")
+	}
+}
+
+// End-to-end deceptive-WAF calibration: a host that answers 200 with a readme
+// carrying "Stable tag:" for the random, certainly-absent slug is flagged as a
+// deceptive WAF, and responses matching that template are suppressed.
+func TestNewCalibratorDeceptiveWAF(t *testing.T) {
+	deceptive := "=== Fake Plugin ===\nStable tag: 9.9.9\nContributors: waf\n" +
+		"This deceptive readme is served for any plugin slug by the firewall.\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(deceptive))
+	}))
+	defer srv.Close()
+
+	client := wphttp.NewHTTPClient(5*time.Second, nil, "", 0, 0)
+	c := NewCalibrator(context.Background(), client, srv.URL)
+
+	if !c.available {
+		t.Fatal("calibration should be available")
+	}
+	if !c.HasDeceptiveWAF() {
+		t.Fatal("a 200 + \"Stable tag:\" response for an absent slug must flag a deceptive WAF")
+	}
+	if !c.IsDeceptiveBody(deceptive) {
+		t.Error("the exact deceptive template must be reported as deceptive")
+	}
+	if c.IsInstalled(http.StatusOK, deceptive) {
+		t.Error("a response matching the deceptive template must be suppressed (miss)")
+	}
+}

--- a/internal/scanner/calibration_test.go
+++ b/internal/scanner/calibration_test.go
@@ -42,8 +42,7 @@ func TestCalibratorIsInstalled(t *testing.T) {
 			signature(404, "nginx not found"): {},
 			signature(301, ""):                {},
 		},
-		missStatusOnly: map[int]struct{}{},
-		available:      true,
+		available: true,
 	}
 	tests := []struct {
 		name   string
@@ -124,9 +123,9 @@ func TestNewCalibratorDynamicNotFound(t *testing.T) {
 	client := wphttp.NewHTTPClient(5*time.Second, nil, "", 0, 0)
 	c := NewCalibrator(context.Background(), client, srv.URL)
 
-	if _, ok := c.missStatusOnly[http.StatusOK]; ok {
-		t.Fatal("normalized dynamic page should be stable, not status-only")
-	}
+	// The per-request digits collapse under normalizedHash, so every dynamic
+	// miss shares one calibrated (200, hash) signature: a differently-numbered
+	// miss is caught by the exact missSigs check without a body-similarity pass.
 	missWithOtherToken := "<!DOCTYPE html><html><head><title>Page not found</title></head><body>error ref 9999 at 17000099999</body></html>"
 	if c.IsInstalled(http.StatusOK, missWithOtherToken) {
 		t.Error("a dynamic soft-404 page must be a miss, not a false positive")
@@ -142,10 +141,9 @@ func TestNewCalibratorDynamicNotFound(t *testing.T) {
 // saw only 404 (issue #27, corvuspay false positive).
 func TestCalibratorRedirectNeverInstalled(t *testing.T) {
 	c := &Calibrator{
-		missStatuses:   map[int]struct{}{404: {}},
-		missSigs:       map[responseSig]struct{}{signature(404, "not found"): {}},
-		missStatusOnly: map[int]struct{}{},
-		available:      true,
+		missStatuses: map[int]struct{}{404: {}},
+		missSigs:     map[responseSig]struct{}{signature(404, "not found"): {}},
+		available:    true,
 	}
 	for _, status := range []int{301, 302, 303, 307, 308} {
 		if c.IsInstalled(status, "") {
@@ -172,9 +170,11 @@ func TestCalibratorRedirectFallback(t *testing.T) {
 }
 
 // A soft-404 host (200 for everything) that echoes the requested path makes
-// every probe body different, even after normalization. The ambiguous 200
-// status must be downgraded to status-only so detection stays conservative (a
-// miss) instead of flagging every probe as a hit.
+// every probe body differ even after normalization. The echoed path is the only
+// varying token, so body-similarity collapses it (similarityToken -> "#path")
+// and a differently-pathed miss still matches the calibrated template above the
+// threshold, keeping detection conservative (a miss) instead of flagging every
+// probe as a hit.
 func TestNewCalibratorEchoingNotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("<html><body>Nothing here at " + r.URL.Path + "</body></html>"))
@@ -184,9 +184,6 @@ func TestNewCalibratorEchoingNotFound(t *testing.T) {
 	client := wphttp.NewHTTPClient(5*time.Second, nil, "", 0, 0)
 	c := NewCalibrator(context.Background(), client, srv.URL)
 
-	if _, ok := c.missStatusOnly[http.StatusOK]; !ok {
-		t.Fatal("an echoing soft-404 (200) should be tracked as a status-only miss")
-	}
 	if c.IsInstalled(http.StatusOK, "<html><body>Nothing here at /whatever</body></html>") {
 		t.Error("an echoing soft-404 200 must be treated as a miss")
 	}

--- a/internal/scanner/modes.go
+++ b/internal/scanner/modes.go
@@ -109,7 +109,6 @@ func performBruteforceScan(ctx ScanExecutionContext) ScanDetectionResult {
 	}
 
 	progress := setupBruteforceProgress(ctx.Opts, ctx.Progress, len(plugins))
-	defer finishBruteforceProgress(progress, ctx.Opts)
 
 	bruteReq := BruteforceRequest{
 		Target:   ctx.Target,
@@ -135,8 +134,6 @@ func performHybridScan(ctx ScanExecutionContext) ScanDetectionResult {
 		return bruteResult
 	}
 
-	finishProgressIfNeeded(ctx.Progress)
-
 	remaining := calculateRemainingPlugins(stealthyResult.Plugins, ctx.Opts)
 	if len(remaining) == 0 {
 		return stealthyResult
@@ -155,9 +152,8 @@ func performHybridScan(ctx ScanExecutionContext) ScanDetectionResult {
 
 func performBruteforceOnRemaining(ctx ScanExecutionContext, remaining []string) ([]string, map[string]string) {
 	var bruteBar Progress
-	if ctx.Opts.File == "" && ctx.Opts.NewProgress != nil {
-		bruteBar = ctx.Opts.NewProgress(len(remaining), "Bruteforcing remaining")
-		defer bruteBar.Finish()
+	if ctx.Opts.File == "" {
+		bruteBar = setupBruteforceProgress(ctx.Opts, ctx.Progress, len(remaining))
 	}
 
 	bruteReq := BruteforceRequest{

--- a/internal/scanner/modes.go
+++ b/internal/scanner/modes.go
@@ -107,15 +107,18 @@ func performBruteforceScan(ctx ScanExecutionContext) ScanDetectionResult {
 		logger.DefaultLogger.Error("Failed to load plugin list: " + err.Error())
 		return ScanDetectionResult{}
 	}
+	logLoadedPlugins(ctx.Progress, len(plugins))
 
 	progress := setupBruteforceProgress(ctx.Opts, ctx.Progress, len(plugins))
+	defer finishBruteforceProgress(progress, ctx.Opts)
 
 	bruteReq := BruteforceRequest{
-		Target:   ctx.Target,
-		Plugins:  plugins,
-		Threads:  ctx.Opts.Threads,
-		Progress: progress,
-		HTTP:     HTTPConfigFromOpts(ctx.Opts),
+		Target:     ctx.Target,
+		Plugins:    plugins,
+		Threads:    ctx.Opts.Threads,
+		Progress:   progress,
+		HTTP:       HTTPConfigFromOpts(ctx.Opts),
+		Calibrator: ctx.Opts.Calibrator,
 	}
 	detected, versions := BruteforcePlugins(bruteReq)
 
@@ -124,7 +127,12 @@ func performBruteforceScan(ctx ScanExecutionContext) ScanDetectionResult {
 }
 
 func performHybridScan(ctx ScanExecutionContext) ScanDetectionResult {
-	logger.DefaultLogger.Info("Starting hybrid scan: first stealthy, then brute-force...")
+	message := "Starting hybrid scan: first stealthy, then brute-force..."
+	if logger.DefaultLogger.Verbose && ctx.Progress != nil {
+		_, _ = ctx.Progress.Bprintln(logger.FormatInfo(message))
+	} else {
+		logger.DefaultLogger.Info(message)
+	}
 
 	stealthyResult := performStealthyScan(ctx)
 
@@ -134,7 +142,9 @@ func performHybridScan(ctx ScanExecutionContext) ScanDetectionResult {
 		return bruteResult
 	}
 
-	remaining := calculateRemainingPlugins(stealthyResult.Plugins, ctx.Opts)
+	finishProgressIfNeeded(ctx.Progress)
+
+	remaining := calculateRemainingPlugins(stealthyResult.Plugins, ctx.Opts, ctx.Progress)
 	if len(remaining) == 0 {
 		return stealthyResult
 	}
@@ -152,16 +162,18 @@ func performHybridScan(ctx ScanExecutionContext) ScanDetectionResult {
 
 func performBruteforceOnRemaining(ctx ScanExecutionContext, remaining []string) ([]string, map[string]string) {
 	var bruteBar Progress
-	if ctx.Opts.File == "" {
-		bruteBar = setupBruteforceProgress(ctx.Opts, ctx.Progress, len(remaining))
+	if ctx.Opts.File == "" && ctx.Opts.NewProgress != nil {
+		bruteBar = ctx.Opts.NewProgress(len(remaining), "Bruteforcing plugins")
+		defer bruteBar.Finish()
 	}
 
 	bruteReq := BruteforceRequest{
-		Target:   ctx.Target,
-		Plugins:  remaining,
-		Threads:  ctx.Opts.Threads,
-		Progress: bruteBar,
-		HTTP:     HTTPConfigFromOpts(ctx.Opts),
+		Target:     ctx.Target,
+		Plugins:    remaining,
+		Threads:    ctx.Opts.Threads,
+		Progress:   bruteBar,
+		HTTP:       HTTPConfigFromOpts(ctx.Opts),
+		Calibrator: ctx.Opts.Calibrator,
 	}
 	detected, versions := BruteforcePlugins(bruteReq)
 	return detected, versions

--- a/internal/scanner/modes.go
+++ b/internal/scanner/modes.go
@@ -122,7 +122,7 @@ func performBruteforceScan(ctx ScanExecutionContext) ScanDetectionResult {
 	}
 	detected, versions := BruteforcePlugins(bruteReq)
 
-	detectedList, result := buildBruteforceResult(detected, versions)
+	detectedList, result := buildBruteforceResult(detected)
 	return ScanDetectionResult{Plugins: detectedList, PluginResult: result, Versions: versions}
 }
 

--- a/internal/scanner/orchestration.go
+++ b/internal/scanner/orchestration.go
@@ -123,6 +123,11 @@ func ScanSite(ctx ScanSiteContext) {
 	default:
 	}
 
+	ctx.Opts.Calibrator = NewScanCalibrator(scanCtx, ctx.Target, ctx.Opts)
+	if ctx.Opts.Calibrator.HasDeceptiveWAF() {
+		DisplayDeceptiveWAFWarning(ctx.Progress)
+	}
+
 	execCtx := ScanExecutionContext{
 		Target:   ctx.Target,
 		Opts:     ctx.Opts,
@@ -131,6 +136,7 @@ func ScanSite(ctx ScanSiteContext) {
 	}
 
 	scanResult := performScan(execCtx, scanMode)
+	scanResult = FilterDeceptiveResults(execCtx, scanResult)
 
 	if len(scanResult.Plugins) == 0 && len(scanResult.Themes) == 0 {
 		handleNoPluginsDetected(ctx)

--- a/internal/scanner/results.go
+++ b/internal/scanner/results.go
@@ -20,6 +20,7 @@
 package scanner
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/Chocapikk/wpprobe/internal/file"
@@ -88,12 +89,13 @@ func buildBruteforceResult(detected []string, versions map[string]string) ([]str
 	return detected, result
 }
 
-func calculateRemainingPlugins(stealthyList []string, opts ScanOptions) []string {
+func calculateRemainingPlugins(stealthyList []string, opts ScanOptions, progress Progress) []string {
 	allPlugins, err := LoadPluginsFromFile(opts.PluginList)
 	if err != nil {
 		logger.DefaultLogger.Error("Failed to load plugin list: " + err.Error())
 		return nil
 	}
+	logLoadedPlugins(progress, len(allPlugins))
 
 	seen := make(map[string]struct{}, len(stealthyList))
 	for _, p := range stealthyList {
@@ -107,6 +109,15 @@ func calculateRemainingPlugins(stealthyList []string, opts ScanOptions) []string
 		}
 	}
 	return remaining
+}
+
+func logLoadedPlugins(progress Progress, pluginCount int) {
+	message := fmt.Sprintf("Loaded %d plugins for brute-force scanning", pluginCount)
+	if logger.DefaultLogger.Verbose && progress != nil {
+		_, _ = progress.Bprintln(logger.FormatInfo(message))
+		return
+	}
+	logger.DefaultLogger.Info(message)
 }
 
 func combineHybridResults(stealthyList []string, stealthyRes PluginDetectionResult, brutefound []string) ([]string, PluginDetectionResult) {
@@ -140,4 +151,3 @@ func handleNoPluginsDetected(ctx ScanSiteContext) {
 
 	writeResults(ctx.Writer, ctx.Target, []file.PluginEntry{})
 }
-

--- a/internal/scanner/results.go
+++ b/internal/scanner/results.go
@@ -75,7 +75,7 @@ func buildDetectionResult(endpoints []string, endpointsData map[string][]string,
 	return result
 }
 
-func buildBruteforceResult(detected []string, versions map[string]string) ([]string, PluginDetectionResult) {
+func buildBruteforceResult(detected []string) ([]string, PluginDetectionResult) {
 	result := PluginDetectionResult{
 		Plugins:  make(map[string]*PluginData, len(detected)),
 		Detected: detected,

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -47,6 +47,7 @@ type ScanOptions struct {
 	Context        context.Context                          // Context for cancellation
 	HTTPClient     *http.Client                             // External HTTP client (optional, for connection pooling)
 	SharedLimiter  *wphttp.RateLimiter                      // Global rate limiter shared across all targets
+	Calibrator     *Calibrator                              // Per-target deceptive response baseline
 	NewProgress    func(total int, message string) Progress // Factory for creating progress bars (CLI only)
 	DisplayFunc    func(DisplayResultsContext)              // Callback for displaying results (CLI only)
 }
@@ -126,11 +127,12 @@ type ScanContext struct {
 
 // BruteforceRequest contains request parameters for bruteforce operations.
 type BruteforceRequest struct {
-	Target   string
-	Plugins  []string
-	Threads  int
-	Progress Progress
-	HTTP     wphttp.Config
+	Target     string
+	Plugins    []string
+	Threads    int
+	Progress   Progress
+	HTTP       wphttp.Config
+	Calibrator *Calibrator
 }
 
 // HybridScanRequest contains request parameters for hybrid scan operations.


### PR DESCRIPTION
## Summary

This PR improves plugin detection reliability against deceptive WAF responses and fixes several CLI and progress-output inconsistencies.

## Brute-force

- Automatically select `hybrid` mode when `--plugin-list/-p` is provided without an explicit mode.
- Reject `--plugin-list` when explicitly combined with `--mode stealthy`.
- Preserve the final report when verbose mode is disabled.
- Display the total number of plugins loaded for brute-force/hybrid scanning.

## WAF calibration

WPProbe now generates a random `no-existing-plugin-XXXXXXXX` slug to establish a per-target calibration baseline. It probes `readme.txt`, `Readme.txt`, and the corresponding plugin PHP file up to five times each, for a maximum of 15 requests, and stops as soon as it receives a `200` response containing `Stable tag:`.

The response body is then used as the deceptive WAF template. Subsequent plugin responses are compared against it using Sørensen-Dice similarity with a 70% threshold. A single calibrator is shared across REST, HTML, and brute-force detection so that matching fake responses are consistently suppressed before the final results are displayed.
